### PR TITLE
還原導覽列排版

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
             font-family: Arial, Helvetica, sans-serif;
             background: #0e0e0e;
             color: #f0f0f0;
+            text-align: center;
         }
         header {
             background: linear-gradient(135deg, #00e0ff, #0066ff);


### PR DESCRIPTION
## 變更內容
- 恢復 `header`、`nav` 與 `nav ul` 的排版設定，使導覽列仍保持靠右排列
- 保留 `body` 的 `text-align: center`，讓各段落文字置中顯示

## 測試
- `npm test` 執行失敗，因缺少 `package.json`【6b30dc†L1-L14】

------
https://chatgpt.com/codex/tasks/task_e_6852a2beae848330897fd4d2e1dc6611