### PR TITLE
調整 Hero 區塊為左右分佈

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,12 @@
         </nav>
     </header>
     <section class="hero">
-        <h2>精銳部隊</h2>
-        <h2>源自於精良設備</h2>
-        <p>結合最新 AI 模型，深度客製化訓練項目</p>
+        <div class="hero-content">
+            <h2>精銳部隊</h2>
+            <h2>源自於精良設備</h2>
+            <p>結合最新 AI 模型，深度客製化訓練項目</p>
+        </div>
+        <img class="hero-image" src="images/6c664bc7-7f5a-4e2d-96e9-23c4bf984424.png" alt="訓練示意圖">
     </section>
     <section id="about">
         <h2>關於飛焜 Falcon X</h2>

--- a/styles.css
+++ b/styles.css
@@ -48,16 +48,26 @@ section {
     padding: 4rem 2rem;
 }
 .hero {
-    background: url('images/6c664bc7-7f5a-4e2d-96e9-23c4bf984424.png') center/cover no-repeat;
-    background-color: rgba(15, 32, 39, 0.6);
-    background-blend-mode: overlay;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 2rem;
     color: #fff;
-    text-align: center;
-    padding: 6rem 2rem;
+    text-align: left;
+    padding: 4rem 2rem;
 }
 .hero h2 {
     font-size: 2.5rem;
     color: #64ffda;
+}
+.hero-content {
+    flex: 1 1 300px;
+}
+.hero-image {
+    flex: 1 1 300px;
+    max-width: 500px;
+    width: 100%;
+    height: auto;
 }
 .products {
     display: flex;


### PR DESCRIPTION
## 變更內容
- Hero 區塊改為左右布局，左側為標語文字，右側顯示原本的背景圖片
- 移除背景設定並新增對應的 `.hero-content` 與 `.hero-image` 樣式

## 測試方式
- 無自動化測試

------
https://chatgpt.com/codex/tasks/task_e_6860f522a8b88330af4eef1eb86a0ca6