### PR TITLE
調整 hero 區塊左右留白

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -55,6 +55,9 @@ section {
     color: #fff;
     text-align: left;
     padding: 4rem 2rem;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
 }
 .hero h2 {
     font-size: 2.5rem;


### PR DESCRIPTION
## 變更內容
- 新增 `.hero` 區塊的 `max-width` 與左右自動外距

## 原因與影響
- 讓 hero 區塊在寬螢幕下保有適當留白，視覺上更舒適

------
https://chatgpt.com/codex/tasks/task_e_6860fe85818083309bb23f29dee51c87